### PR TITLE
Allow shorter parquet file endings

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,8 +11,7 @@ pub fn file_format(filename: &str) -> Result<FileFormat, Error> {
             "avro" => Ok(FileFormat::Avro),
             "csv" => Ok(FileFormat::Csv),
             "json" => Ok(FileFormat::Json),
-            "parquet" => Ok(FileFormat::Parquet),
-            "parq" => Ok(FileFormat::Parquet),
+            "parquet" | "parq" => Ok(FileFormat::Parquet),
             other => Err(Error::General(format!(
                 "unsupported file extension '{}'",
                 other

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,6 +12,7 @@ pub fn file_format(filename: &str) -> Result<FileFormat, Error> {
             "csv" => Ok(FileFormat::Csv),
             "json" => Ok(FileFormat::Json),
             "parquet" => Ok(FileFormat::Parquet),
+            "parq" => Ok(FileFormat::Parquet),
             other => Err(Error::General(format!(
                 "unsupported file extension '{}'",
                 other


### PR DESCRIPTION
bdt strictly uses file only ending on .parquet. However some systems also use shorter endings like *.parq (e.g. Cloudera Impala Hive...)


I am pretty sure, there are more short forms that bdt should support.