### PR TITLE
File ending Issue

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bdt::compare::ComparisonResult;
-use bdt::utils::{file_format, parse_filename};
+use bdt::utils::{file_ending, file_format, parse_filename};
 use bdt::{compare, Error, FileFormat};
 use comfy_table::{Cell, Table};
 use datafusion::common::DataFusionError;
@@ -366,8 +366,15 @@ async fn register_table(
                 .await?
         }
         FileFormat::Parquet => {
-            ctx.register_parquet(table_name, filename, ParquetReadOptions::default())
-                .await?
+            ctx.register_parquet(
+                table_name,
+                filename,
+                ParquetReadOptions {
+                    file_extension: &file_ending(filename)?,
+                    ..Default::default()
+                },
+            )
+            .await?
         }
     }
     ctx.table(table_name).map_err(Error::from)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,21 +6,25 @@ use datafusion::common::ScalarValue;
 use std::path::Path;
 
 pub fn file_format(filename: &str) -> Result<FileFormat, Error> {
-    match filename.rfind('.') {
-        Some(i) => match &filename[i + 1..] {
-            "avro" => Ok(FileFormat::Avro),
-            "csv" => Ok(FileFormat::Csv),
-            "json" => Ok(FileFormat::Json),
-            "parquet" | "parq" => Ok(FileFormat::Parquet),
-            other => Err(Error::General(format!(
-                "unsupported file extension '{}'",
-                other
-            ))),
-        },
-        _ => Err(Error::General(format!(
-            "Could not determine file extension for '{}'",
-            filename
+    match file_ending(filename)?.as_str() {
+        "avro" => Ok(FileFormat::Avro),
+        "csv" => Ok(FileFormat::Csv),
+        "json" => Ok(FileFormat::Json),
+        "parquet" | "parq" => Ok(FileFormat::Parquet),
+        other => Err(Error::General(format!(
+            "unsupported file extension '{}'",
+            other
         ))),
+    }
+}
+
+pub fn file_ending(filename: &str) -> Result<String, Error> {
+    if let Some(ending) = std::path::Path::new(filename).extension() {
+        Ok(ending.to_string_lossy().to_string())
+    } else {
+        Err(Error::General(
+            "Could not determine file extension".to_string(),
+        ))
     }
 }
 


### PR DESCRIPTION
Sorry, I did not test my previous PR. The file ending needs to be passed into the `ParquetReadOptions`.
 
I took the liberty to refactor the file ending parsing a bit. Please tell me if it is OK, or not.

I have just tested this for `view` and `schema` of files that end with `.parq` and `.parquet`

