### PR TITLE
"One file output" option added for csv/json.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bdt"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "comfy-table 6.2.0",
  "datafusion",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -41,6 +41,8 @@ enum Command {
     },
     /// Convert a file to a different format
     Convert {
+        #[structopt(short, long)]
+        one_file: bool,
         #[structopt(parse(from_os_str))]
         input: PathBuf,
         #[structopt(parse(from_os_str))]
@@ -127,10 +129,10 @@ async fn execute_command(cmd: Command) -> Result<(), Error> {
             let df = ctx.sql(sql).await?;
             df.show().await?;
         }
-        Command::Convert { input, output } => {
+        Command::Convert { one_file, input, output } => {
             let input_filename = parse_filename(&input)?;
             let output_filename = parse_filename(&output)?;
-            convert_files(&ctx, input_filename, output_filename).await?;
+            convert_files(&ctx, input_filename, output_filename, one_file).await?;
         }
         Command::Query {
             table,

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -8,9 +8,10 @@ pub async fn convert_files(
     ctx: &SessionContext,
     input_filename: &str,
     output_filename: &str,
+    one_file: bool
 ) -> Result<Vec<RecordBatch>, Error> {
     let df = register_table(ctx, "t", input_filename).await?;
-    let write_options = DataFrameWriteOptions::default();
+    let write_options = DataFrameWriteOptions::default().with_single_file_output(one_file);
     match file_format(output_filename)? {
         FileFormat::Avro => Err(Error::General(
             "Conversion to Avro is not supported".to_string(),


### PR DESCRIPTION
The default output for csv and json files by datafusion is to output a series of files inside a directory named as the output file.  I find it quite inconvenient so I have added `-o/--one-file` option.  I have switched to `clap`a long time ago so I'm not sure how to rename the option (I agree `-o`  is not ideal) so feel free to change it 😁.  Thanks a lot for `bdt` BTW, it beats writing it myself.